### PR TITLE
changed 'http' to 'https' for the id_token setIssuer function

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -57,7 +57,7 @@ class IdTokenResponse extends BearerTokenResponse
         // Add required id_token claims
         $builder = (new Builder())
             ->setAudience($accessToken->getClient()->getIdentifier())
-            ->setIssuer('http://' . $_SERVER['HTTP_HOST'])
+            ->setIssuer('https://' . $_SERVER['HTTP_HOST'])
             ->setIssuedAt(time())
             ->setExpiration($accessToken->getExpiryDateTime()->getTimestamp())
             ->setSubject($userEntity->getIdentifier());

--- a/tests/ResponseTypes/IdTokenResponseTest.php
+++ b/tests/ResponseTypes/IdTokenResponseTest.php
@@ -68,7 +68,7 @@ class IdTokenResponseTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $_SERVER['HTTP_HOST'] = 'http://localhost';
+        $_SERVER['HTTP_HOST'] = 'https://localhost';
         $responseType = new IdTokenResponse(
             new IdentityProvider(IdentityProvider::NO_CLAIMSET),
             new ClaimExtractor()
@@ -114,7 +114,7 @@ class IdTokenResponseTest extends TestCase
 
     private function processResponseType($responseType, array $scopeNames = ['basic'])
     {
-        $_SERVER['HTTP_HOST'] = 'http://localhost';
+        $_SERVER['HTTP_HOST'] = 'https://localhost';
         $responseType->setPrivateKey(
             new CryptKey('file://' . __DIR__ . '/../Stubs/private.key')
         );


### PR DESCRIPTION
According to OIDC core the value of iss is an https URL, not http [1]. 

(discovered trying to figure out why the server is on https and the issuer in the id_token was http...)

Davide
--
[1] https://openid.net/specs/openid-connect-core-1_0.html#IDToken