### PR TITLE
Moved JWT builder in IdTokenResponse to protected method

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -35,6 +35,19 @@ class IdTokenResponse extends BearerTokenResponse
         $this->claimExtractor   = $claimExtractor;
     }
 
+    protected function getBuilder(AccessTokenEntityInterface $accessToken, UserEntityInterface $userEntity)
+    {
+        // Add required id_token claims
+        $builder = (new Builder())
+            ->setAudience($accessToken->getClient()->getIdentifier())
+            ->setIssuer('https://' . $_SERVER['HTTP_HOST'])
+            ->setIssuedAt(time())
+            ->setExpiration($accessToken->getExpiryDateTime()->getTimestamp())
+            ->setSubject($userEntity->getIdentifier());
+
+        return $builder;
+    }
+
     /**
      * @param AccessTokenEntityInterface $accessToken
      * @return array
@@ -55,12 +68,7 @@ class IdTokenResponse extends BearerTokenResponse
         }
 
         // Add required id_token claims
-        $builder = (new Builder())
-            ->setAudience($accessToken->getClient()->getIdentifier())
-            ->setIssuer('https://' . $_SERVER['HTTP_HOST'])
-            ->setIssuedAt(time())
-            ->setExpiration($accessToken->getExpiryDateTime()->getTimestamp())
-            ->setSubject($userEntity->getIdentifier());
+        $builder = $this->getBuilder($accessToken, $userEntity);
 
         // Need a claim factory here to reduce the number of claims by provided scope.
         $claims = $this->claimExtractor->extract($accessToken->getScopes(), $userEntity->getClaims());


### PR DESCRIPTION
It's very hard to add more claims or headers to `id_token`. This PR moves builder generation in a protected method, so the class can be extended to add more claims. Vg:

```php
<?php

class MyIdTokenResponse extends IdTokenResponse
{
    protected function getBuilder(AccessTokenEntityInterface $accessToken, UserEntityInterface $userEntity)
    {
        // Add required id_token claims
        $builder = parent::getBuilder($accessToken, $userEntity)
            ->setHeader('kid', 'oidc')
        ;

        return $builder;
    }
}
```

This not cause any BC.