### PR TITLE
Add compatibility with league/oauth-server 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "league/oauth2-server": "^5.1|^6.0|^7.0"
+        "league/oauth2-server": "^5.1|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",


### PR DESCRIPTION
From my local tests, there appear to be no changes in version 8.0 of League's `oauth-server` that interfere with this library. It should be possible for you to update your compatibility to include the 8.x series without any issues.