### PR TITLE
refactor: move away from deprecated interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "league/oauth2-server": "^5.1|^6.0|^7.0|^8.0"
+        "league/oauth2-server": "^5.1|^6.0|^7.0|^8.0",
+        "lcobucci/jwt": "^3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -39,11 +39,11 @@ class IdTokenResponse extends BearerTokenResponse
     {
         // Add required id_token claims
         $builder = (new Builder())
-            ->setAudience($accessToken->getClient()->getIdentifier())
-            ->setIssuer('https://' . $_SERVER['HTTP_HOST'])
-            ->setIssuedAt(time())
-            ->setExpiration($accessToken->getExpiryDateTime()->getTimestamp())
-            ->setSubject($userEntity->getIdentifier());
+            ->permittedFor($accessToken->getClient()->getIdentifier())
+            ->issuedBy('https://' . $_SERVER['HTTP_HOST'])
+            ->issuedAt(time())
+            ->expiresAt($accessToken->getExpiryDateTime()->getTimestamp())
+            ->relatedTo($userEntity->getIdentifier());
 
         return $builder;
     }
@@ -78,8 +78,7 @@ class IdTokenResponse extends BearerTokenResponse
         }
 
         $token = $builder
-            ->sign(new Sha256(), new Key($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase()))
-            ->getToken();
+            ->getToken(new Sha256(), new Key($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase()));
 
         return [
             'id_token' => (string) $token

--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -74,7 +74,7 @@ class IdTokenResponse extends BearerTokenResponse
         $claims = $this->claimExtractor->extract($accessToken->getScopes(), $userEntity->getClaims());
 
         foreach ($claims as $claimName => $claimValue) {
-            $builder->set($claimName, $claimValue);
+            $builder = $builder->withClaim($claimName, $claimValue);
         }
 
         $token = $builder


### PR DESCRIPTION
Use the newer (non-deprecated) token builder methods to build the id_token.