### PR TITLE
Upgraded lcobucci/jwt from v3 to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ $publicKeyPath = 'file://' . __DIR__ . '/../public.key';
 // OpenID Connect Response Type
 $responseType = new IdTokenResponse(new IdentityRepository(), new ClaimExtractor());
 
+// Optionally configure the issued id token before it is signed
+$responseType->setIdTokenModifier(function(\Lcobucci\JWT\Token\Builder $token) {
+   return $token->issuedBy('Custom issuer')
+                ->withClaim('customClaim', 'Custom claim')
+                ->withHeader('kid', 'key-id');
+});
+
 // Setup the authorization server
 $server = new \League\OAuth2\Server\AuthorizationServer(
     $clientRepository,

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "league/oauth2-server": "^5.1|^6.0|^7.0|^8.0",
-        "lcobucci/jwt": "^3.3"
+        "lcobucci/jwt": "^3.4|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -3,20 +3,20 @@
  * @author Steve Rhoades <sedonami@gmail.com>
  * @license http://opensource.org/licenses/MIT MIT
  */
+
 namespace OpenIDConnectServer;
 
 use DateTimeImmutable;
-use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Configuration;
-use Lcobucci\JWT\Token\Builder;
-use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Key\LocalFileReference;
-use OpenIDConnectServer\Entities\ClaimSetInterface;
-use League\OAuth2\Server\Entities\UserEntityInterface;
-use League\OAuth2\Server\Entities\ScopeEntityInterface;
-use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token\Builder;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OAuth2\Server\Entities\UserEntityInterface;
+use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
+use OpenIDConnectServer\Entities\ClaimSetInterface;
 use OpenIDConnectServer\Repositories\IdentityProviderInterface;
 
 class IdTokenResponse extends BearerTokenResponse
@@ -46,7 +46,7 @@ class IdTokenResponse extends BearerTokenResponse
         ClaimExtractor $claimExtractor
     ) {
         $this->identityProvider = $identityProvider;
-        $this->claimExtractor   = $claimExtractor;
+        $this->claimExtractor = $claimExtractor;
     }
 
     /**
@@ -120,7 +120,7 @@ class IdTokenResponse extends BearerTokenResponse
     private function isOpenIDRequest($scopes)
     {
         // Verify scope and make sure openid exists.
-        $valid  = false;
+        $valid = false;
 
         foreach ($scopes as $scope) {
             if ($scope->getIdentifier() === 'openid') {

--- a/tests/ResponseTypes/IdTokenResponseTest.php
+++ b/tests/ResponseTypes/IdTokenResponseTest.php
@@ -2,26 +2,20 @@
 
 namespace OpenIDConnectServer\Test\ResponseTypes;
 
-use Zend\Diactoros\Response;
-use Lcobucci\JWT\Token\Parser;
-use Lcobucci\JWT\Token\Builder;
-use PHPUnit\Framework\TestCase;
-use Zend\Diactoros\ServerRequest;
-use League\OAuth2\Server\CryptKey;
-use LeagueTests\Stubs\ScopeEntity;
-use LeagueTests\Stubs\ClientEntity;
 use Lcobucci\JWT\Encoding\JoseEncoder;
-use OpenIDConnectServer\ClaimExtractor;
-use Psr\Http\Message\ResponseInterface;
+use Lcobucci\JWT\Token\Builder;
+use Lcobucci\JWT\Token\Parser;
+use League\OAuth2\Server\CryptKey;
 use LeagueTests\Stubs\AccessTokenEntity;
-use OpenIDConnectServer\IdTokenResponse;
+use LeagueTests\Stubs\ClientEntity;
 use LeagueTests\Stubs\RefreshTokenEntity;
+use LeagueTests\Stubs\ScopeEntity;
+use OpenIDConnectServer\ClaimExtractor;
+use OpenIDConnectServer\IdTokenResponse;
 use OpenIDConnectServer\Test\Stubs\IdentityProvider;
-use League\OAuth2\Server\Exception\OAuthServerException;
-use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
-use LeagueTests\ResponseTypes\BearerTokenResponseWithParams;
-use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
-use League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Zend\Diactoros\Response;
 
 class IdTokenResponseTest extends TestCase
 {
@@ -132,7 +126,7 @@ class IdTokenResponseTest extends TestCase
         $responseType->setIdTokenModifier(function ($token) {
             return true; // does not return instance of Builder
         });
-        
+
         $this->processResponseType($responseType, ['openid']);
     }
 


### PR DESCRIPTION
See https://github.com/steverhoades/oauth2-openid-connect-server/pull/32#issuecomment-772994411 for explanation.

This PR also introduces a new idTokenModifier api, that has the ability to modify the created id token before it is signed. 
The library currently has no way of giving a developer access / influence on how the token is created. There are many, many optional claims that sometimes need to be filled, for example a the key id (kid) claim for third party signature validation or even a custom issuer (iss) claim (currently this is hardcoded to `https:// . $_SERVER['HTTP_HOST']`).

A user can call `IdTokenResponse->setIdTokenModifier(callable $tokenModifier): void`. This callable will receive the created instance of Lcobucci\JWT\Token\Builder as its first and only argument. The custom callable can then modifier it, e.g. add a custom claim and must then return the instance. 

This step is completely optional and fully backwards compatible.



