### PR TITLE
Fix travis configuration + DateTime-bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,12 @@ matrix:
       env: LEAGUE_VERSION=8.0.*  JWT_VERSION=3.4.*
 
     - php: 7.4
-      env: LEAGUE_VERSION=8.0.*  JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=^8.0  JWT_VERSION=^3.4
     - php: 7.4
-      env: LEAGUE_VERSION=8.0.*  JWT_VERSION=^4
+      env: LEAGUE_VERSION=^8.0  JWT_VERSION=^4.0
 
     - php: 8.0
-      env: LEAGUE_VERSION=8.0.*  JWT_VERSION=4.1.*
+      env: LEAGUE_VERSION=^8.0  JWT_VERSION=^4.0
 
 before_install:
   - composer require league/oauth2-server:$LEAGUE_VERSION --prefer-source --no-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: bionic
+dist: xenial
 sudo: false
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,6 @@ cache:
   directories:
     - vendor
 
-env:
-  - LEAGUE_VERSION=5.1.*
-  - JWT_VERSION=3.4.*
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.4
-  - 8.0
-
 matrix:
   include:
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,89 +10,53 @@ cache:
 matrix:
   include:
     - php: 5.6
-      env: 
-      - LEAGUE_VERSION=5.1.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=5.1.*  JWT_VERSION=3.4.*
     - php: 5.6
-      env: 
-      - LEAGUE_VERSION=6.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=6.0.*  JWT_VERSION=3.4.*
     - php: 5.6
-      env: 
-      - LEAGUE_VERSION=6.1.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=6.1.*  JWT_VERSION=3.4.*
+
     - php: 7.0
-      env: 
-      - LEAGUE_VERSION=5.1.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=5.1.*  JWT_VERSION=3.4.*
     - php: 7.0
-      env: 
-      - LEAGUE_VERSION=6.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=6.0.*  JWT_VERSION=3.4.*
     - php: 7.0
-      env: 
-      - LEAGUE_VERSION=6.1.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=6.1.*  JWT_VERSION=3.4.*
     - php: 7.0
-      env: 
-      - LEAGUE_VERSION=7.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=7.0.*  JWT_VERSION=3.4.*
+
     - php: 7.1
-      env: 
-      - LEAGUE_VERSION=5.1.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=5.1.*  JWT_VERSION=3.4.*
     - php: 7.1
-      env: 
-      - LEAGUE_VERSION=6.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=6.0.*  JWT_VERSION=3.4.*
     - php: 7.1
-      env: 
-      - LEAGUE_VERSION=6.1.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=6.1.*  JWT_VERSION=3.4.*
     - php: 7.1
-      env: 
-      - LEAGUE_VERSION=7.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=7.0.*  JWT_VERSION=3.4.*
     - php: 7.1
-      env: 
-      - LEAGUE_VERSION=8.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=8.0.*  JWT_VERSION=3.4.*
+
     - php: 7.2
-      env: 
-      - LEAGUE_VERSION=5.1.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=5.1.*  JWT_VERSION=3.4.*
     - php: 7.2
-      env: 
-      - LEAGUE_VERSION=6.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=6.0.*  JWT_VERSION=3.4.*
     - php: 7.2
-      env: 
-      - LEAGUE_VERSION=6.1.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=6.1.*  JWT_VERSION=3.4.*
     - php: 7.2
-      env: 
-      - LEAGUE_VERSION=7.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=7.0.*  JWT_VERSION=3.4.*
     - php: 7.2
-      env: 
-      - LEAGUE_VERSION=8.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=8.0.*  JWT_VERSION=3.4.*
+
     - php: 7.3
-      env: 
-      - LEAGUE_VERSION=8.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=8.0.*  JWT_VERSION=3.4.*
+
     - php: 7.4
-      env:
-      - LEAGUE_VERSION=8.0.*
-      - JWT_VERSION=^4
+      env: LEAGUE_VERSION=8.0.*  JWT_VERSION=3.4.*
     - php: 7.4
-      env:
-      - LEAGUE_VERSION=8.0.*
-      - JWT_VERSION=3.4.*
+      env: LEAGUE_VERSION=8.0.*  JWT_VERSION=^4
+
     - php: 8.0
-      env:
-      - LEAGUE_VERSION=8.0.*
-      - JWT_VERSION=4.1.*
+      env: LEAGUE_VERSION=8.0.*  JWT_VERSION=4.1.*
 
 before_install:
   - composer require league/oauth2-server:$LEAGUE_VERSION --prefer-source --no-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ cache:
   directories:
     - vendor
 
+env:
+  global:
+    XDEBUG_MODE=coverage
+
 matrix:
   include:
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ install:
   - composer update --prefer-source --no-interaction
 
 script:
-  - vendor/bin/phpunit --coverage-clover=coverage.clover
+  - php -d error_reporting="E_ALL & ~E_USER_DEPRECATED" vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
     - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: trusty
+dist: bionic
 sudo: false
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "lcobucci/jwt": "^3.4.3|^4.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^5.0|^9.5",
         "zendframework/zend-diactoros": "^1.3.2"
     },
     "autoload": {

--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -43,12 +43,18 @@ class IdTokenResponse extends BearerTokenResponse
             $builder = new \Lcobucci\JWT\Builder();
         }
 
+        // Since version 8.0 league/oauth2-server returns \DateTimeImmutable
+        $expiresAt = $accessToken->getExpiryDateTime();
+        if ($expiresAt instanceof \DateTime) {
+            $expiresAt = \DateTimeImmutable::createFromMutable($expiresAt);
+        }
+
         // Add required id_token claims
         $builder
             ->permittedFor($accessToken->getClient()->getIdentifier())
             ->issuedBy('https://' . $_SERVER['HTTP_HOST'])
             ->issuedAt(new \DateTimeImmutable())
-            ->expiresAt($accessToken->getExpiryDateTime())
+            ->expiresAt($expiresAt)
             ->relatedTo($userEntity->getIdentifier());
 
         return $builder;

--- a/tests/ResponseTypes/IdTokenResponseTest.php
+++ b/tests/ResponseTypes/IdTokenResponseTest.php
@@ -29,7 +29,7 @@ class IdTokenResponseTest extends TestCase
 
         $response->getBody()->rewind();
         $json = json_decode($response->getBody()->getContents());
-        self::assertAttributeEquals('Bearer', 'token_type', $json);
+        self::assertEquals('Bearer', $json->token_type);
         self::assertObjectHasAttribute('expires_in', $json);
         self::assertObjectHasAttribute('access_token', $json);
         self::assertObjectHasAttribute('refresh_token', $json);
@@ -48,7 +48,7 @@ class IdTokenResponseTest extends TestCase
 
         $response->getBody()->rewind();
         $json = json_decode($response->getBody()->getContents());
-        self::assertAttributeEquals('Bearer', 'token_type', $json);
+        self::assertEquals('Bearer', $json->token_type);
         self::assertObjectHasAttribute('expires_in', $json);
         self::assertObjectHasAttribute('access_token', $json);
         self::assertObjectHasAttribute('refresh_token', $json);
@@ -96,7 +96,7 @@ class IdTokenResponseTest extends TestCase
         $response->getBody()->rewind();
         $json = json_decode($response->getBody()->getContents(),false);
 
-        self::assertAttributeEquals('Bearer', 'token_type', $json);
+        self::assertEquals('Bearer', $json->token_type);
         self::assertObjectHasAttribute('expires_in', $json);
         self::assertObjectHasAttribute('access_token', $json);
         self::assertObjectHasAttribute('refresh_token', $json);


### PR DESCRIPTION
After the merge of #36, I saw @steverhoades struggling with the Travis setup. While I'm not experienced with Travis, I decided to dive into it, because I really would like to upgrade my environment to PHP 8.

There where three causes for the failing runs:
- The matrix was effectively defined twice, due to the extra environment variable now the tests ran also for incomplete env-setups
- Tests where failing because of deprecations in older environments, for which a decission should be made if the will be maintained (and the deprecations should be fixed) or not (deprecations are fine). That's why I have changed the Travis-config to ignore deprecations
- After fixing those issues, I ran into an error in the specific combination of oAuth2-server 8.0 and lcobucci/JWT 3.4.*, which I've fixed

And after some failed runs:
- Updated Ubuntu-version to Xenial, to support PHP 5.6 as well as 8.0
- Allowed to use version 9.5 of PHPUnit, since 5.0 does not support PHP 8.0