### PR TITLE
Put jti/scopes claims in token

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -52,6 +52,8 @@ class IdTokenResponse extends BearerTokenResponse
         // Add required id_token claims
         $builder
             ->permittedFor($accessToken->getClient()->getIdentifier())
+            ->identifiedBy($accessToken->getIdentifier())
+            ->withClaim('scopes', array_map(fn (ScopeEntityInterface $scope): string => $scope->getIdentifier(), $accessToken->getScopes()))
             ->issuedBy('https://' . $_SERVER['HTTP_HOST'])
             ->issuedAt(new \DateTimeImmutable())
             ->expiresAt($expiresAt)


### PR DESCRIPTION
Hi,

This fixes various compatibility issues for us, namely:

```
Uncaught Error: Argument 1 passed to League\Bundle\OAuth2ServerBundle\Manager\Doctrine\AccessTokenManager::find() 
must be of the type string, null given
```

at https://github.com/thephpleague/oauth2-server/blob/8ab731e84eef904b5913ba31b38116acf8ea50b6/src/AuthorizationValidators/BearerTokenValidator.php#L122

and

```
Argument 1 passed to League\Bundle\OAuth2ServerBundle\Security\Passport\Badge\ScopeBadge::__construct() 
must be of the type array, null given
```

at https://github.com/thephpleague/oauth2-server-bundle/blob/272facbb7e4313afd5a4dc7e8871f9d101a74efb/src/Security/Authenticator/OAuth2Authenticator.php#L119