### PR TITLE
Update IdTokenResponse.php

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -50,14 +50,12 @@ class IdTokenResponse extends BearerTokenResponse
         }
 
         // Add required id_token claims
-        $builder
+        return $builder
             ->permittedFor($accessToken->getClient()->getIdentifier())
             ->issuedBy('https://' . $_SERVER['HTTP_HOST'])
             ->issuedAt(new \DateTimeImmutable())
             ->expiresAt($expiresAt)
             ->relatedTo($userEntity->getIdentifier());
-
-        return $builder;
     }
 
     /**


### PR DESCRIPTION
Currently there is a bug in which the default claims are not set. This happens because all the claim set operations are returning a new instance instead of setting the value on the current object