### PR TITLE
Make it possible to override the issuer

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -30,12 +30,18 @@ class IdTokenResponse extends BearerTokenResponse
      */
     protected $claimExtractor;
 
+    /**
+     * @var string
+     */
+    protected $issuer;
+
     public function __construct(
         IdentityProviderInterface $identityProvider,
         ClaimExtractor $claimExtractor
     ) {
         $this->identityProvider = $identityProvider;
         $this->claimExtractor   = $claimExtractor;
+        $this->issuer = 'https://' . $_SERVER['HTTP_HOST'];
     }
 
     protected function getBuilder(AccessTokenEntityInterface $accessToken, UserEntityInterface $userEntity)
@@ -52,7 +58,7 @@ class IdTokenResponse extends BearerTokenResponse
         // Add required id_token claims
         return $builder
             ->permittedFor($accessToken->getClient()->getIdentifier())
-            ->issuedBy('https://' . $_SERVER['HTTP_HOST'])
+            ->issuedBy($this->issuer)
             ->issuedAt(new \DateTimeImmutable())
             ->expiresAt($expiresAt)
             ->relatedTo($userEntity->getIdentifier());
@@ -122,4 +128,8 @@ class IdTokenResponse extends BearerTokenResponse
         return $valid;
     }
 
+    public function setIssuer(string $issuer)
+    {
+        $this->issuer = $issuer;
+    }
 }

--- a/tests/ResponseTypes/IdTokenResponseTest.php
+++ b/tests/ResponseTypes/IdTokenResponseTest.php
@@ -70,10 +70,10 @@ class IdTokenResponseTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $_SERVER['HTTP_HOST'] = 'https://localhost';
         $responseType = new IdTokenResponse(
             new IdentityProvider(IdentityProvider::NO_CLAIMSET),
-            new ClaimExtractor()
+            new ClaimExtractor(),
+            'https://localhost'
         );
         $this->processResponseType($responseType, $privateKey, ['openid']);
         self::fail('Exception should have been thrown');


### PR DESCRIPTION
This makes configuring the issuer more flexible.

For example, when using a framework like Symfony, it is preferable to not use the global `$_SERVER` array, but to use the `Request` object to get the host.

There might also be other cases where someone does not want to use the domainname from the `Host` HTTP header, but some other canonical domainname.