### PR TITLE
Added kid header in id token

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -30,12 +30,19 @@ class IdTokenResponse extends BearerTokenResponse
      */
     protected $claimExtractor;
 
+    /**
+     * @var string|null
+     */
+    protected $keyIdentifier;
+    
     public function __construct(
         IdentityProviderInterface $identityProvider,
-        ClaimExtractor $claimExtractor
+        ClaimExtractor $claimExtractor,
+        ?string $keyIdentifier = null
     ) {
         $this->identityProvider = $identityProvider;
         $this->claimExtractor   = $claimExtractor;
+        $this->keyIdentifier   = $keyIdentifier;
     }
 
     protected function getBuilder(AccessTokenEntityInterface $accessToken, UserEntityInterface $userEntity)
@@ -85,6 +92,10 @@ class IdTokenResponse extends BearerTokenResponse
 
         foreach ($claims as $claimName => $claimValue) {
             $builder = $builder->withClaim($claimName, $claimValue);
+        }
+
+        if ($this->keyIdentifier !== null) {
+            $builder = $builder->withHeader('kid', $keyIdentifier);
         }
 
         if (


### PR DESCRIPTION
Public keys may be rotating from time to time to enchance security and prevent leaks. It's good to add `kid` header into an id token to allow clients to recognize the keys they must use to check the token signature.

See about `kid`s in the JWKS URI: https://openid.net/specs/openid-connect-core-1_0.html#RotateSigKeys
And in the ID token: https://openid.net/specs/openid-connect-core-1_0.html#id_tokenExample

In this PR I added optional parameter `keyIdentifier` to ID token response class. If it's set, the kid parameter will be passed into the ID token header. If not, it won't.