### PR TITLE
Add parameter types for repository methods

### DIFF
--- a/src/Repositories/ClaimSetRepositoryInterface.php
+++ b/src/Repositories/ClaimSetRepositoryInterface.php
@@ -8,5 +8,5 @@ namespace OpenIDConnectServer\Repositories;
 
 interface ClaimSetRepositoryInterface
 {
-    public function getClaimSetByScopeIdentifier($scopeIdentifier);
+    public function getClaimSetByScopeIdentifier(string $scopeIdentifier);
 }

--- a/src/Repositories/IdentityProviderInterface.php
+++ b/src/Repositories/IdentityProviderInterface.php
@@ -14,5 +14,5 @@ interface IdentityProviderInterface extends RepositoryInterface
     /**
      * @return UserEntityInterface&ClaimSetInterface
      */
-    public function getUserEntityByIdentifier($identifier);
+    public function getUserEntityByIdentifier(string $identifier);
 }


### PR DESCRIPTION
As parent classes need to add parameter types before child classes, this will allow projects to use parameter types on their implementation.

This is not a BC break for implementers of the interface thanks to the covariance support implemented in PHP 7.2 (and the fact that this package does not support older PHP versions anymore).